### PR TITLE
only structs should be checked for exported/unexported fields

### DIFF
--- a/deepcopy/deepcopy.go
+++ b/deepcopy/deepcopy.go
@@ -50,7 +50,7 @@ func InterfaceToSliceOfInts(v interface{}) []int {
 			sl[i] = s.Index(i).Interface().(int)
 		}
 	case reflect.Int:
-			sl = append(sl, reflect.ValueOf(v).Interface().(int))
+		sl = append(sl, reflect.ValueOf(v).Interface().(int))
 	default:
 		return nil
 	}
@@ -84,15 +84,9 @@ func copyRecursive(original, copy reflect.Value) {
 		if !originalValue.IsValid() {
 			return
 		}
-		if !copy.CanSet() {
-			return
-		}
 		copy.Set(reflect.New(originalValue.Type()))
 		copyRecursive(originalValue, copy.Elem())
 	case reflect.Interface:
-		if !copy.CanSet() {
-			return
-		}
 		// Get the value for the interface, not the pointer.
 		originalValue := original.Elem()
 		if !originalValue.IsValid() {
@@ -105,21 +99,17 @@ func copyRecursive(original, copy reflect.Value) {
 	case reflect.Struct:
 		// Go through each field of the struct and copy it.
 		for i := 0; i < original.NumField(); i++ {
-			copyRecursive(original.Field(i), copy.Field(i))
+			if copy.Field(i).CanSet() {
+				copyRecursive(original.Field(i), copy.Field(i))
+			}
 		}
 	case reflect.Slice:
-		if !copy.CanSet() {
-			return
-		}
 		// Make a new slice and copy each element.
 		copy.Set(reflect.MakeSlice(original.Type(), original.Len(), original.Cap()))
 		for i := 0; i < original.Len(); i++ {
 			copyRecursive(original.Index(i), copy.Index(i))
 		}
 	case reflect.Map:
-		if !copy.CanSet() {
-			return
-		}
 		copy.Set(reflect.MakeMap(original.Type()))
 		for _, key := range original.MapKeys() {
 			originalValue := original.MapIndex(key)
@@ -129,30 +119,15 @@ func copyRecursive(original, copy reflect.Value) {
 		}
 	// Set the actual values from here on.
 	case reflect.String:
-		if !original.CanSet() || !copy.CanSet() {
-			return
-		}
 		copy.SetString(original.Interface().(string))
 	case reflect.Int:
-		if !original.CanSet() || !copy.CanSet() {
-			return
-		}
 		copy.SetInt(int64(original.Interface().(int)))
 	case reflect.Bool:
-		if !original.CanSet() || !copy.CanSet() {
-			return
-		}
 		copy.SetBool(original.Interface().(bool))
 	case reflect.Float64:
-		if !original.CanSet() || !copy.CanSet() {
-			return
-		}
 		copy.SetFloat(original.Interface().(float64))
 
 	default:
-		if !original.CanSet() || !copy.CanSet() {
-			return
-		}
 		copy.Set(original)
 	}
 }

--- a/deepcopy/deepcopy_test.go
+++ b/deepcopy/deepcopy_test.go
@@ -131,3 +131,43 @@ func TestIface(t *testing.T) {
 		}
 	}
 }
+
+// TestStruct has both exported and unexported fields for testing can set.
+type TestStruct struct {
+	Strings string
+	strings string
+	Ints    int
+	ints    int
+	SSlice  []string
+	sSlice  []string
+	ISlice  []int
+	iSlice  []int
+	SSMap   map[string]string
+	sSMap   map[string]string
+}
+
+func TestCanSet(t *testing.T) {
+	tst := TestStruct{
+		Strings: "an exported string",
+		strings: "an unexported string",
+		Ints:    42,
+		ints:    11,
+		SSlice:  []string{"hello", "world"},
+		sSlice:  []string{"don't", "panic"},
+		ISlice:  []int{1, 2, 3},
+		iSlice:  []int{42, 11},
+		SSMap:   map[string]string{"french": "bonjour", "spanish": "hola"},
+		sSMap:   map[string]string{"french": "au revoir", "spanish": "adios"},
+	}
+	expected := TestStruct{
+		Strings: "an exported string",
+		Ints:    42,
+		SSlice:  []string{"hello", "world"},
+		ISlice:  []int{1, 2, 3},
+		SSMap:   map[string]string{"french": "bonjour", "spanish": "hola"},
+	}
+	cpy := Iface(tst)
+	if json.MarshalToString(cpy) != json.MarshalToString(expected) {
+		t.Errorf("Expected copy to be %#v, got %#v\n", expected, cpy)
+	}
+}


### PR DESCRIPTION
all reflect types are checked with CanCopy, this results in failure of some tests. Only structs should be checked for unexported fields, and if they exist, don't copy.
